### PR TITLE
Add python2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.python2?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=185&branchName=master)
+
+# python2
+
+Python is a programming language that lets you work quickly and integrate systems more effectively.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "python2"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/controls/python_works.rb
+++ b/controls/python_works.rb
@@ -2,7 +2,7 @@ title 'Tests to confirm python2 works as expected'
 
 plan_name = input('plan_name', value: 'python2')
 plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-hab_path = input('hab_path', value: 'hab')
+hab_path = input('hab_path', value: '/tmp/hab')
 
 control 'core-plans-python2' do
   impact 1.0
@@ -29,13 +29,11 @@ control 'core-plans-python2' do
     its('exit_status') { should eq 0 }
     its('stdout') { should be_empty }
     its('stderr') { should match /Python\s+#{python_pkg_ident.split('/')[5]}/ }
-    its('stderr') { should_not be_empty }
   end
 
   describe command("#{python_pkg_ident}/bin/python -c \"print('hello world')\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /hello world/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/controls/python_works.rb
+++ b/controls/python_works.rb
@@ -1,0 +1,41 @@
+title 'Tests to confirm python2 works as expected'
+
+plan_name = input('plan_name', value: 'python2')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-python2' do
+  impact 1.0
+  title 'Ensure python2 works'
+  desc '
+  For python we check that the version is correctly returned e.g.
+
+    $ python --version
+    Python 2.7.12
+
+  As is often customary, we also say hello to the world with python:
+
+    $ python -c "print(\'hello world\')"
+    hello world
+  '
+  python_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe python_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  python_pkg_ident = python_pkg_ident.stdout.strip
+
+  describe command("#{python_pkg_ident}/bin/python --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should be_empty }
+    its('stderr') { should match /Python\s+#{python_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should_not be_empty }
+  end
+
+  describe command("#{python_pkg_ident}/bin/python -c \"print('hello world')\"") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /hello world/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: python2
+title: Habitat Core Plan for Python 2
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan for Python 2
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,42 @@
+$pkg_name="python2"
+$pkg_version="2.7.18"
+$pkg_origin="core"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=@('Python-2.0')
+$pkg_description="Python is a programming language that lets you work quickly and integrate systems more effectively."
+$pkg_upstream_url="https://www.python.org"
+$pkg_source="https://www.python.org/ftp/python/$pkg_version/python-$pkg_version.amd64.msi"
+$pkg_shasum="b74a3afa1e0bf2a6fc566a7b70d15c9bfabba3756fb077797d16fffa27800c05"
+$pkg_build_deps=@("core/lessmsi")
+$pkg_bin_dirs=@("bin", "bin/Scripts")
+
+function Invoke-SetupEnvironment {
+    Set-RuntimeEnv "PYTHONIOENCODING" "UTF-8"
+    Set-BuildtimeEnv "PYTHONIOENCODING" "UTF-8"
+}
+
+function Invoke-Unpack {
+    mkdir "$HAB_CACHE_SRC_PATH/$pkg_dirname" | Out-Null
+
+    Push-Location "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+    try {
+        lessmsi x (Resolve-Path "$HAB_CACHE_SRC_PATH/$pkg_filename").Path
+    } finally { Pop-Location }
+}
+
+function Invoke-Build {
+    $getPipScript = "$HAB_CACHE_SRC_PATH/$pkg_dirname/get-pip.py"
+    Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile $getPipScript
+    ."$HAB_CACHE_SRC_PATH/$pkg_dirname/python-$pkg_version.amd64/SourceDir/python.exe" $getPipScript --no-warn-script-location
+}
+
+function Invoke-Install {
+    Remove-Item "$pkg_prefix/bin/Scripts"
+
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/python-$pkg_version.amd64/SourceDir/*" "$pkg_prefix/bin" -Recurse
+}
+
+function Invoke-Check {
+    & "$HAB_CACHE_SRC_PATH/$pkg_dirname/python-$pkg_version.amd64/SourceDir/python" -m pip --version
+    if($LASTEXITCODE -ne 0) { Write-Error "Invoke check failed with error code $LASTEXITCODE" }
+}

--- a/plan.sh
+++ b/plan.sh
@@ -24,6 +24,20 @@ pkg_build_deps=(
   core/util-linux
 )
 
+pkg_deps=(
+  core/bzip2
+  core/expat
+  core/gcc-libs
+  core/gdbm
+  core/glibc
+  core/libffi
+  core/ncurses
+  core/openssl
+  core/readline
+  core/sqlite
+  core/zlib
+)
+
 pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 
 do_build() {

--- a/plan.sh
+++ b/plan.sh
@@ -61,6 +61,10 @@ do_build() {
     make
 }
 
+do_check() {
+  make test
+}
+
 do_install() {
   do_default_install
 

--- a/plan.sh
+++ b/plan.sh
@@ -15,6 +15,14 @@ pkg_upstream_url="https://www.python.org"
 pkg_dirname="${pkg_distname}-${pkg_version}"
 pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
 pkg_shasum="da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814"
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/linux-headers
+  core/make
+  core/util-linux
+)
 
 pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,45 @@
+# shellcheck disable=SC2148,SC1091
+source ../python/plan.sh
+
+# TODO: Should this be renamed to python27 in accordance with RFC 0003?
+# If so, the python2 namespace would need to be deprecated per RFC 0007
+pkg_name=python2
+pkg_distname=Python
+pkg_version=2.7.18
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814"
+
+pkg_interpreters=(bin/python bin/python2 bin/python2.7)
+
+do_build() {
+    # TODO: We should build with `--enable-optimizations`
+    ./configure --prefix="$pkg_prefix" \
+                --enable-shared \
+                --enable-unicode=ucs4 \
+                --with-threads \
+                --with-system-expat \
+                --with-system-ffi \
+                --with-ensurepip
+
+    make
+}
+
+do_install() {
+  do_default_install
+
+  # Remove idle as we are not building with Tk/x11 support so it is useless
+  rm -vf "$pkg_prefix/bin/idle"
+
+  platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
+  cat <<EOF > "$platlib/_manylinux.py"
+# Disable binary manylinux1(CentOS 5) wheel support
+manylinux1_compatible = False
+EOF
+}

--- a/plan.sh
+++ b/plan.sh
@@ -58,10 +58,4 @@ do_install() {
 
   # Remove idle as we are not building with Tk/x11 support so it is useless
   rm -vf "$pkg_prefix/bin/idle"
-
-  platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
-  cat <<EOF > "$platlib/_manylinux.py"
-# Disable binary manylinux1(CentOS 5) wheel support
-manylinux1_compatible = False
-EOF
 }


### PR DESCRIPTION
Migration from core plans, adding inspec tests:

```
Profile: Habitat Core Plan for Python 2 (python2)
Version: 0.1.0
Target:  docker://92e6b38d7628ea03088ded3a0e6e0e4aa33d1d47a957d8ee8cc0990bebd81258

  ✔  core-plans-python2: Ensure python2 works
     ✔  Command: `hab pkg path habskp/python2` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/python2` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python --version` stdout is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python --version` stderr is expected to match /Python\s+2.7.18/
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python --version` stderr is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python -c "print('hello world')"` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python -c "print('hello world')"` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python -c "print('hello world')"` stdout is expected to match /hello world/
     ✔  Command: `/hab/pkgs/habskp/python2/2.7.18/20200610133405/bin/python -c "print('hello world')"` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 10 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
